### PR TITLE
Made future lines semi-transparent (50%) and past lines fully opaque,…

### DIFF
--- a/media/modules/gcode-visualizer.js
+++ b/media/modules/gcode-visualizer.js
@@ -82,9 +82,11 @@ export function updateAllLineColors() {
     else if (isSingleCursor) {
       line.renderOrder = 0;
       if (lineNum < currentLineNumber) {
+        // Past (already executed) path: fully opaque
         line.material = userData.moveCommandType === 'G0' ? materials.line.rapid : materials.line.feed;
       } else {
-        line.material = materials.line.dimmed;
+        // Future (not yet executed) path: same color, 50% transparent
+        line.material = userData.moveCommandType === 'G0' ? materials.line.rapidTransparent : materials.line.feedTransparent;
       }
     }
     // Default case

--- a/media/modules/materials.js
+++ b/media/modules/materials.js
@@ -19,6 +19,9 @@ export const materials = {
     line: {
         feed: new THREE.LineBasicMaterial(),
         rapid: new THREE.LineBasicMaterial(),
+        // Semi-transparent variants for future (not-yet-passed) path preview
+        feedTransparent: new THREE.LineBasicMaterial({ transparent: true, opacity: 0.5 }),
+        rapidTransparent: new THREE.LineBasicMaterial({ transparent: true, opacity: 0.5 }),
         highlight: new THREE.LineBasicMaterial({ depthTest: true }),
         dimmed: new THREE.LineBasicMaterial(),
         hover: new THREE.LineBasicMaterial({ depthTest: false }), // Always on top
@@ -55,6 +58,9 @@ export function updateAllMaterials() {
     // Line colors
     materials.line.feed.color.set(getFeedColor(backgroundColor));
     materials.line.rapid.color.set(getRapidColor(backgroundColor));
+    // Keep transparent variants in sync with base colors
+    materials.line.feedTransparent.color.set(getFeedColor(backgroundColor));
+    materials.line.rapidTransparent.color.set(getRapidColor(backgroundColor));
     materials.line.highlight.color.set(getHighlightColor(backgroundColor));
     materials.line.dimmed.color.set(getDimmedColor(backgroundColor));
     materials.line.hover.color.set(getHoverColor(backgroundColor));

--- a/media/modules/scene.js
+++ b/media/modules/scene.js
@@ -53,7 +53,7 @@ export function init() {
     state.scene = new THREE.Scene();
     state.scene.background = new THREE.Color(0x000000); // Placeholder, will be set by theme manager
 
-    state.camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+    state.camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 8000);
     state.camera.position.set(20, 20, 50);
     state.camera.up.set(0, 0, 1);
 


### PR DESCRIPTION
- Made upcoming (future) toolpath lines semi-transparent (50%) for better visual clarity
- Kept completed (past) lines fully opaque while preserving their original rapid/feed colors
- Increased render distance to 8 meters for improved visibility of larger toolpaths
<img width="897" height="886" alt="Screenshot_1" src="https://github.com/user-attachments/assets/9cec7c50-c068-4bb9-bfd0-d76a22481da4" />
